### PR TITLE
Update nebula plugins to new namespace and versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.48.0'
     id 'com.github.spotbugs' version '5.1.3' apply false
     id 'com.google.osdetector' version '1.7.3'
-    id 'nebula.info-dependencies' version '11.4.1' apply false
-    id 'nebula.maven-nebula-publish' version '18.4.0' apply false
+    id 'com.netflix.nebula.info' version '12.1.6' apply false
+    id 'com.netflix.nebula.maven-base-publish' version '20.3.0' apply false
     id 'net.ltgt.errorprone' version '3.1.0' apply false
     id 'org.sonarqube' version '4.3.1.3277'
     id 'com.autonomousapps.dependency-analysis' version '1.22.0'
@@ -170,7 +170,7 @@ allprojects {
         apply plugin: 'idea'
         apply plugin: 'jacoco'
         apply plugin: 'eclipse'
-        apply plugin: 'nebula.info'
+        apply plugin: 'com.netflix.nebula.info'
         apply plugin: 'maven-publish'
 
         java {
@@ -372,8 +372,8 @@ allprojects {
             systemProperty 'org.tweetwallfx.tests.executeConferenceClientLiveTests', executeConferenceClientLiveTests
         }
 
-        apply plugin: 'nebula.maven-publish'
-        apply plugin: 'nebula.publish-verification'
+        apply plugin: 'com.netflix.nebula.maven-base-publish'
+        apply plugin: 'com.netflix.nebula.publish-verification'
     }
 }
 


### PR DESCRIPTION
This removes some build warning concerning deprecated gradle features.

